### PR TITLE
Support for multiple servers

### DIFF
--- a/bundle/src/main/java/com/meltmedia/dropwizard/jest/JestConfiguration.java
+++ b/bundle/src/main/java/com/meltmedia/dropwizard/jest/JestConfiguration.java
@@ -15,9 +15,12 @@
  */
 package com.meltmedia.dropwizard.jest;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class JestConfiguration {
   protected String clusterName;
-  protected String uri;
+  protected List<String> servers;
   protected int connectionTimeout = 30000;
   protected int readTimeout = 30000;
   protected int maxTotalConnection = 1;
@@ -35,20 +38,45 @@ public class JestConfiguration {
     this.clusterName = clusterName;
     return this;
   }
-
+  
+  /**
+   * @deprecated Use {@link #getServers()} instead.
+   */
+  @Deprecated
   public String getUri() {
-    return uri;
+	return servers == null || servers.isEmpty() ? null : servers.get(0);
   }
 
+  /**
+   * @deprecated Use {@link #setServers(List)} instead
+   */
+  @Deprecated
   public void setUri( String uri ) {
-    this.uri = uri;
+    this.servers = Arrays.asList(uri);
   }
   
+  /**
+   * @deprecated Use {@link #withServers(String...)} instead
+   */
+  @Deprecated
   public JestConfiguration withUri( String uri ) {
-    this.uri = uri;
+	this.servers = Arrays.asList(uri);
     return this;
   }
 
+  public List<String> getServers() {
+    return servers;
+  }
+
+  public void setServers( List<String> servers ) {
+    this.servers = servers;
+  }
+  
+  public JestConfiguration withServers( String... servers ) {
+    this.servers = Arrays.asList(servers);
+    return this;
+  }
+  
   public int getConnectionTimeout() {
     return connectionTimeout;
   }

--- a/bundle/src/main/java/com/meltmedia/dropwizard/jest/JestManager.java
+++ b/bundle/src/main/java/com/meltmedia/dropwizard/jest/JestManager.java
@@ -38,7 +38,7 @@ public class JestManager implements Managed {
   public void start() throws Exception {
     JestClientFactory factory = new JestClientFactory();
     factory.setHttpClientConfig(new HttpClientConfig
-                           .Builder(configuration.getUri())
+                           .Builder(configuration.getServers())
                            .multiThreaded(true)
                            .connTimeout(configuration.getConnectionTimeout())
                            .readTimeout(configuration.getReadTimeout())

--- a/example/conf/example.yml
+++ b/example/conf/example.yml
@@ -1,3 +1,5 @@
 elasticsearch:
   clusterName: elasticsearch
-  uri: 'http://localhost:9200'
+  servers:
+  - 'http://localhost:9200'
+  

--- a/example/src/main/java/com/meltmedia/dropwizard/jest/example/resources/RootResource.java
+++ b/example/src/main/java/com/meltmedia/dropwizard/jest/example/resources/RootResource.java
@@ -99,7 +99,7 @@ public class RootResource {
         JestResult result =
             clientSupplier.get().execute(
                 new Search.Builder(new SearchSourceBuilder()
-                    .query(QueryBuilders.queryString(query)).toString()).addIndex(indexName)
+                    .query(QueryBuilders.queryStringQuery(query)).toString()).addIndex(indexName)
                     .build());
         if (!result.isSucceeded()) {
           log.error("could not search for resource: " + result.getJsonString());
@@ -134,7 +134,7 @@ public class RootResource {
         JestResult result =
             clientSupplier.get().execute(
                 new Search.Builder(new SearchSourceBuilder()
-                    .query(QueryBuilders.queryString(query)).toString()).addIndex(indexName)
+                    .query(QueryBuilders.queryStringQuery(query)).toString()).addIndex(indexName)
                     .addType(typeName).build());
         if (!result.isSucceeded()) {
           log.error("could not search for document: " + result.getJsonString());

--- a/example/src/test/java/com/meltmedia/dropwizard/jest/example/resources/RootResourceIT.java
+++ b/example/src/test/java/com/meltmedia/dropwizard/jest/example/resources/RootResourceIT.java
@@ -19,6 +19,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 
 import org.junit.After;
@@ -28,8 +34,6 @@ import org.junit.Test;
 
 import com.meltmedia.dropwizard.jest.example.ExampleApplication;
 import com.meltmedia.dropwizard.jest.example.ExampleConfiguration;
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
 
 public class RootResourceIT {
 
@@ -45,17 +49,17 @@ public class RootResourceIT {
 
   @Before
   public void setUp() {
-    client = new Client();
+	  client = ClientBuilder.newClient();
   }
 
   @After
   public void tearDown() {
-    client.destroy();
+    client.close();
   }
 
   @Test
   public void shouldCreateNewDocument() {
-    ClientResponse response = putDocument("index/type/id", "{\"name\":\"value\"}");
+    Response response = putDocument("index/type/id", "{\"name\":\"value\"}");
 
     assertThat(response.getStatus(), equalTo(200));
 
@@ -63,11 +67,11 @@ public class RootResourceIT {
   }
 
   public String getDocument(String path) {
-    return client.resource(rootPath().path(path).build()).get(String.class);
+	  return client.target(rootPath()).path(path).request().get(String.class);
   }
 
-  public ClientResponse putDocument(String path, String document) {
-    return client.resource(rootPath().path(path).build()).entity(document, "application/json")
-        .put(ClientResponse.class);
+  public Response putDocument(String path, String document) {
+    WebTarget target = client.target(rootPath()).path(path);
+    return target.request(MediaType.APPLICATION_JSON).put(Entity.entity(document, MediaType.APPLICATION_JSON));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@
   </scm>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <io.dropwizard.version>0.7.1</io.dropwizard.version>
-    <jest.version>0.1.5</jest.version>
-    <elasticsearch.version>1.4.2</elasticsearch.version>
+    <io.dropwizard.version>0.8.4</io.dropwizard.version>
+    <jest.version>0.1.7</jest.version>
+    <elasticsearch.version>1.7.1</elasticsearch.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>


### PR DESCRIPTION
Jest supports multiple servers (which are accessed in a balanced fashion). This is not possible with the current dropwizard-plugin. This PR adds the support for multiple servers while keeping it backward compatible (with the <code>uri</code> property).
The Integration test (in the example module) is also adapted. Furthermore, I updated to dropwizard v0.8.4 and Jest v0.1.7.
