### PR TITLE
upgrade to Jest 2.0.0, Dropwizard 1.0.0, Elasticsearch 2.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You will also need to include the project in your dependencies.
 <dependency>
   <groupId>com.meltmedia.dropwizard</groupId>
   <artifactId>dropwizard-jest</artifactId>
-  <version>0.5.0</version>
+  <version>0.5.1</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You will also need to include the project in your dependencies.
 <dependency>
   <groupId>com.meltmedia.dropwizard</groupId>
   <artifactId>dropwizard-jest</artifactId>
-  <version>0.4.0-SNAPSHOT</version>
+  <version>0.5.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Releases of this project are available on Maven Central.  You can include the pr
 <dependency>
   <groupId>com.meltmedia.dropwizard</groupId>
   <artifactId>dropwizard-jest</artifactId>
-  <version>0.3.0</version>
+  <version>0.5.1</version>
 </dependency>
 ```
 

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.meltmedia.dropwizard</groupId>
     <artifactId>dropwizard-jest-parent</artifactId>
-    <version>0.5.0</version>
+    <version>0.5.1</version>
   </parent>
   <artifactId>dropwizard-jest</artifactId>
   <packaging>jar</packaging>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.meltmedia.dropwizard</groupId>
     <artifactId>dropwizard-jest-parent</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0</version>
   </parent>
   <artifactId>dropwizard-jest</artifactId>
   <packaging>jar</packaging>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.meltmedia.dropwizard</groupId>
     <artifactId>dropwizard-jest-parent</artifactId>
-    <version>0.5.0</version>
+    <version>0.5.1</version>
   </parent>
   <artifactId>dropwizard-jest-example</artifactId>
   <packaging>jar</packaging>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.meltmedia.dropwizard</groupId>
     <artifactId>dropwizard-jest-parent</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0</version>
   </parent>
   <artifactId>dropwizard-jest-example</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </parent>
   <groupId>com.meltmedia.dropwizard</groupId>
   <artifactId>dropwizard-jest-parent</artifactId>
-  <version>0.5.0</version>
+  <version>0.5.1</version>
   <packaging>pom</packaging>
   <name>Dropwizard Jest Parent</name>
   <description>A Dropwizard Bundle for accessing Elasticsearch.</description>
@@ -47,8 +47,8 @@
   </scm>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <io.dropwizard.version>1.0.2</io.dropwizard.version>
-    <jest.version>2.0.0</jest.version>
+    <io.dropwizard.version>1.0.3</io.dropwizard.version>
+    <jest.version>2.0.3</jest.version>
     <elasticsearch.version>2.4.1</elasticsearch.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </parent>
   <groupId>com.meltmedia.dropwizard</groupId>
   <artifactId>dropwizard-jest-parent</artifactId>
-  <version>0.4.0-SNAPSHOT</version>
+  <version>0.5.0</version>
   <packaging>pom</packaging>
   <name>Dropwizard Jest Parent</name>
   <description>A Dropwizard Bundle for accessing Elasticsearch.</description>
@@ -47,9 +47,9 @@
   </scm>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <io.dropwizard.version>0.8.4</io.dropwizard.version>
-    <jest.version>0.1.7</jest.version>
-    <elasticsearch.version>1.7.1</elasticsearch.version>
+    <io.dropwizard.version>1.0.2</io.dropwizard.version>
+    <jest.version>2.0.0</jest.version>
+    <elasticsearch.version>2.4.1</elasticsearch.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>


### PR DESCRIPTION
Jest 0.7.1 has issues decoding errors (error thrown while decoding errors), so for our project we needed the more recent version that fixes this problem. 

Seems too simple to be true, but all the tests pass. I'm unsure about the correct versioning to use.

It's my first PR ever, go easy on me!
